### PR TITLE
PDHMM Bug Fix: JacobianLogTable cache memory leak 

### DIFF
--- a/src/main/native/pdhmm/MathUtils.cc
+++ b/src/main/native/pdhmm/MathUtils.cc
@@ -61,6 +61,11 @@ void JacobianLogTable::initCache()
     cache = result;
 }
 
+void JacobianLogTable::freeCache()
+{
+    _mm_free(cache);
+}
+
 double JacobianLogTable::cacheIntToDouble(int k)
 {
     return log10(1.0 + pow(10.0, -k * TABLE_STEP));

--- a/src/main/native/pdhmm/MathUtils.h
+++ b/src/main/native/pdhmm/MathUtils.h
@@ -42,6 +42,7 @@ public:
     static double get(double difference);
 
     static void initCache();
+    static void freeCache();
 
 private:
     static double cacheIntToDouble(int i);

--- a/src/main/native/pdhmm/pdhmm-common.h
+++ b/src/main/native/pdhmm/pdhmm-common.h
@@ -142,6 +142,7 @@ inline void freeInit(double *matchToMatchLog10, double *matchToMatchProb,
                      double *qualToErrorProbCache,
                      double *qualToProbLog10Cache)
 {
+    JacobianLogTable::freeCache();
     _mm_free(matchToMatchLog10);
     _mm_free(matchToMatchProb);
     _mm_free(qualToErrorProbCache);


### PR DESCRIPTION
This PR fixes a memory leak in PDHMM implementation. 