### PR TITLE
smithwaterman bug fix

### DIFF
--- a/src/main/native/smithwaterman/PairWiseSW.h
+++ b/src/main/native/smithwaterman/PairWiseSW.h
@@ -60,9 +60,8 @@
             VEC_STOREU((VEC_INT_TYPE *)(&H[hCurInd]), h11); \
             }
 
-static uint32_t D_MAX_SEQ_LEN = MAX_SEQ_LEN;
 
-void inline smithWatermanBackTrack(SeqPair *p, int32_t match, int32_t mismatch, int32_t open, int32_t extend, int32_t* E_,int32_t tid)
+void inline smithWatermanBackTrack(SeqPair *p, int32_t match, int32_t mismatch, int32_t open, int32_t extend, int32_t* E_,int32_t tid, uint32_t D_MAX_SEQ_LEN)
 {
     uint32_t seq1[D_MAX_SEQ_LEN];
     uint32_t seq1Rev[D_MAX_SEQ_LEN];
@@ -262,7 +261,7 @@ void inline smithWatermanBackTrack(SeqPair *p, int32_t match, int32_t mismatch, 
     return;
 }
 
-void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t cigarBufLength, int32_t tid)
+void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t cigarBufLength, int32_t tid, uint32_t D_MAX_SEQ_LEN)
 {
     int16_t *btrack = p->btrack;
     int16_t max_i = p->max_i;
@@ -459,7 +458,7 @@ int32_t CONCAT(runSWOnePairBT_,SIMD_ENGINE)(int32_t match, int32_t mismatch, int
     int32_t  w_extend = extend;
 
     
-    D_MAX_SEQ_LEN = MAX_SEQ_LEN;
+    uint32_t D_MAX_SEQ_LEN = MAX_SEQ_LEN;
 
     int len = max(len1, len2);
 
@@ -488,8 +487,8 @@ int32_t CONCAT(runSWOnePairBT_,SIMD_ENGINE)(int32_t match, int32_t mismatch, int
     p.btrack = backTrack_;
     p.cigar = cigarArray;
 
-    smithWatermanBackTrack(&p, match, mismatch,  open, extend, E_, 0);
-    getCIGAR(&p, cigarBuf_, cigarLen, 0);
+    smithWatermanBackTrack(&p, match, mismatch,  open, extend, E_, 0, D_MAX_SEQ_LEN);
+    getCIGAR(&p, cigarBuf_, cigarLen, 0, D_MAX_SEQ_LEN);
     (*cigarCount) = p.cigarCount;
 
     _mm_free(E_);


### PR DESCRIPTION
This PR resolves an issue where the global static variable D_MAX_SEQ_LEN was not being updated correctly due to multiple copies across translation units. This led to inconsistent behavior and, in some cases, illegal memory access. The variable has now been refactored to ensure correct initialization and usage across the codebase.